### PR TITLE
修正 date 及 author 錯置問題

### DIFF
--- a/src/Us/Crawler/Engine/PttCrawler.php
+++ b/src/Us/Crawler/Engine/PttCrawler.php
@@ -50,7 +50,11 @@ class PttCrawler
         }
     }
 
-    // 主程式邏輯
+    /**
+     * 主程式邏輯
+     *
+     * @return void
+     */
     private function main()
     {
         $state = 0;
@@ -187,7 +191,12 @@ class PttCrawler
         return $last_page;
     }
 
-    // 取得當頁的文章基本資料
+    /**
+     * 取得當頁的文章基本資料
+     *
+     * @param int $index 頁數
+     * @return void
+     */
     private function fetchPage($index)
     {
         $this->errorOutput("fetching page: " . $index . "\n");
@@ -211,9 +220,9 @@ class PttCrawler
                     $count = 0;
                 }
             } elseif ($count % 3 == 2) {
-                $post_temp["date"] = $element->plaintext;
-            } else {
                 $post_temp["author"] = $element->plaintext;
+            } else {
+                $post_temp["date"] = $element->plaintext;
                 array_push($result, $post_temp);
                 $post_temp = array();
             }

--- a/src/Us/Crawler/Storage/RDBStorage.php
+++ b/src/Us/Crawler/Storage/RDBStorage.php
@@ -1,4 +1,6 @@
-<?php namespace Us\Crawler\Storage;
+<?php
+
+namespace Us\Crawler\Storage;
 
 use \PDO;
 use \PDOException;


### PR DESCRIPTION
author 和 date 欄位因使用順位抓取的方式，原先網頁欄位順位不同，造成
取出的內容錯置。先改變目前的順位解決當前問題。再找時間修改成比較好的
方式。